### PR TITLE
Fix news screen styles

### DIFF
--- a/app/components/HeaderImage.js
+++ b/app/components/HeaderImage.js
@@ -10,9 +10,12 @@ export default function HeaderImage({ imgUrl, title }) {
   return (
     <ImageBackground
       loadingIndicatorSource={placeholder}
+      resizeMode='cover'
+      resizeMethod='scale'
       style={styles.container}
       source={imgUrl}>
       <LinearGradient
+        style={styles.gradient}
         colors={['rgba(0,0,0,0)', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.6)']}>
         <Text style={styles.title}>{title}</Text>
       </LinearGradient>
@@ -22,8 +25,7 @@ export default function HeaderImage({ imgUrl, title }) {
 
 const styles = StyleSheet.create({
   container: {
-    // width: '100%',
-    height: 'auto',
+    height: 200,
   },
   description: {
     fontSize: 11,
@@ -34,10 +36,10 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.primaryBold,
     color: Colors.WHITE,
     fontSize: 17,
+    padding: 20,
   },
   gradient: {
     justifyContent: 'flex-end',
-    padding: 20,
     flex: 1,
     resizeMode: 'cover',
   },


### PR DESCRIPTION
<!-- ## Description -->

Change header styles of news screen

#### Linked issues:

Fixes [#41](https://trello.com/c/ohIZ2L7e/41-news-screen)

#### Screenshots:

* Before

<img width="385" alt="Screen Shot 2020-05-14 at 2 41 16 PM" src="https://user-images.githubusercontent.com/42479747/81973040-8dfc4a80-95f1-11ea-8716-4efcfb772322.png">

* After

<img width="385" alt="Screen Shot 2020-05-14 at 2 30 59 PM" src="https://user-images.githubusercontent.com/42479747/81973059-95bbef00-95f1-11ea-94cf-3ba200375674.png">


#### How to test

- `git fetch && git checkout fix/news-styles`
- Run the app
- Test if looks like the mockup
