### PR TITLE
Fixing splash screen, now safe path splash not showing

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -13,7 +13,6 @@
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:statusBarColor">@color/ic_launcher_background</item>
         <item name="android:windowBackground">@color/ic_launcher_background</item>
-        <item name="android:background">@drawable/background_splash</item>
         <item name="colorPrimaryDark">@color/ic_launcher_background</item>
     </style>
 


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

**Description:** Just fixing splash screen, now the splash from safe paths not show up.

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

**Linked issues:** [Ticket](https://trello.com/c/xA0mf6MQ/108-fix-splash-screen-in-android)

<!-- Add issues here e.g.: Fixes #1234 -->

**Screenshots:** 
![photo5093706659460655316](https://user-images.githubusercontent.com/46538610/83557835-55f57280-a4e0-11ea-9a39-5a29e8e9c1be.jpg)

<!-- If you're changing visuals, add a screenshot here -->

**How to test:** You're going to see it when you start the app.

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
