### PR TITLE
Map starting at user location and restoring navigation to report screen

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -151,6 +151,11 @@ class Entry extends Component {
             }}
           />
           <Stack.Screen
+            name='Report'
+            component={Report}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
             name='Results'
             component={ResultsScreen}
             options={{ headerShown: false }}

--- a/app/views/DR/Maps/Map.js
+++ b/app/views/DR/Maps/Map.js
@@ -27,7 +27,7 @@ import {
 
 const latitudeDelta = 0.0052;
 const longitudeDelta = 0.0081;
-const rdCoords = { latitude: 18.7009, longitude: -70.1655 };
+const rdCoords = { latitude: 0, longitude: 0 };
 const { height } = Dimensions.get('window');
 
 export default function HospitalMap({ route: { name: type } }) {
@@ -48,6 +48,8 @@ export default function HospitalMap({ route: { name: type } }) {
       Geolocation.getCurrentPosition(
         ({ coords }) => {
           const { latitude, longitude } = coords;
+          rdCoords.latitude = latitude;
+          rdCoords.longitude = longitude;
           const sorted = sortByDistance({ latitude, longitude }, value, {
             yName: 'latitude',
             xName: 'longitude',
@@ -63,6 +65,8 @@ export default function HospitalMap({ route: { name: type } }) {
         Geolocation.getCurrentPosition(
           ({ coords }) => {
             const { latitude, longitude } = coords;
+            rdCoords.latitude = latitude;
+            rdCoords.longitude = longitude;
             const sorted = sortByDistance({ latitude, longitude }, value, {
               yName: 'latitude',
               xName: 'longitude',


### PR DESCRIPTION

#### Description:

When map section is open starts in user location instead of a fixed point in the map

#### Linked issues:

[Related ticket](https://trello.com/c/ZIhMfAhx/137-en-el-mapa-de-hospitales-o-laboratorios-inicialmente-muestra-una-ubicaci%C3%B3n-que-no-es-la-del-usuario)

#### Screenshots:

<img width="570" alt="Screen Shot 2020-06-09 at 3 48 44 PM" src="https://user-images.githubusercontent.com/57003769/84192981-c3694c00-aa68-11ea-8f61-6e6c87daab47.png">


#### How to test:

Open the app and navigate to the map section 
