### PR TITLE
Changing label for button in News

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -114,7 +114,7 @@
     "launch_location_access": "Location access",
     "launch_location_header": "To remember where you go, your phone needs to save your location.",
     "launch_location_subheader": "Don’t worry, information never leaves your device unless you explicitly decide to share.",
-    "launch_next": "Next",
+    "launch_next": "See more",
     "launch_notif_header": "Notifications will let you know if you cross paths with an infected person.",
     "launch_notif_subheader": "We won't bother you except to share updates on your potential exposure risks.",
     "launch_notification_access": "Allow notifications",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -109,7 +109,7 @@
     "launch_location_access": "Acceder a tu ubicación",
     "launch_location_header": "Para recordar donde has estado, tu teléfono móvil necesita registrar tu ubicación.",
     "launch_location_subheader": "No te preocupes, estos datos nunca saldrán de tu móvil sin tu consentimiento expreso.",
-    "launch_next": "Siguiente",
+    "launch_next": "Ver más",
     "launch_notif_header": "Con las notificaciones, podrás saber si has estado cerca de alguien con COVID.",
     "launch_notif_subheader": "No te molestaremos salvo para enviarte información sobre tu riesgo de exposición.",
     "launch_notification_access": "No te molestaremos salvo para enviarte información sobre tu riesgo de exposición.",


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

**Description:** Just a change of label for English and Spanish version, now the button in news says "Ver Más" for Spanish and "See more" for English.

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

**Linked issues:** [Ticket](https://trello.com/c/krdOnZHz/132-cambiar-bot%C3%B3n-ver-m%C3%A1s-en-vez-de-siguiente)

<!-- Add issues here e.g.: Fixes #1234 -->

**Screenshots:**
![photo5118678149075413121](https://user-images.githubusercontent.com/46538610/84297427-86aa5d00-ab1b-11ea-8dda-90e8306058e6.jpg)
![photo5118678149075413122](https://user-images.githubusercontent.com/46538610/84297433-890cb700-ab1b-11ea-9327-610b43f127de.jpg)

<!-- If you're changing visuals, add a screenshot here -->

**How to test:** Just go to News Screen with English language or Spanish language to see the button in the bottom of the screen.

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
