### PR TITLE
adding Term of Use in spanish

### DIFF
--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -11,12 +11,13 @@ import Colors from '../constants/colors';
 import buttonStyle from '../constants/DR/buttonStyles';
 import { Theme } from '../constants/themes';
 import en from '../locales/eula/en.html';
+import es from '../locales/eula/es.html';
 import ht from '../locales/eula/ht.html';
 import { Checkbox } from './Checkbox';
 import { IconButton } from './IconButton';
 import { Typography } from './Typography';
 
-const EULA_FILES = { en, ht };
+const EULA_FILES = { en, ht, es };
 
 const DEFAULT_EULA_URL = 'about:blank';
 

--- a/app/locales/eula/es.html
+++ b/app/locales/eula/es.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <style>
+      html {
+        font-size: 13px;
+      }
+
+      ol,
+      ul {
+        padding-left: 5px;
+        margin-left: 5px;
+      }
+      li{
+        margin-top: 3%;
+      }
+      .letteredOrdered {
+        list-style: lower-alpha;
+      }
+      .romanOrdered {
+        list-style: lower-roman;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h2><strong>COVID Safe Paths</strong></h2>
+    <h3><strong>Acuerdo de Licencia de Usuario Final de la Aplicación Móvil</strong></h3>
+    <p>
+        Este Acuerdo de Licencia de Usuario Final de la Aplicación Móvil ("<strong>Acuerdo</strong>")
+        es un acuerdo vinculante entre usted ("<strong>Usuario final</strong>" o "<strong>usted</strong>") y Path Check, Inc. 
+        ("<strong>Compañía</strong>"). Este Acuerdo rige su uso de COVID Safe Paths, 
+        (incluyendo toda la documentación relacionada, la "<strong>Aplicación</strong>"). La Aplicación tiene 
+        licencia de uso, no se le vende.
+    </p>
+    <p>
+        AL UTILIZAR LA APLICACIÓN, USTED (A) RECONOCE QUE HA LEÍDO Y COMPRENDE ESTE ACUERDO; 
+        (B) ASEGURA QUE USTED TIENE [18 AÑOS O MÁS / EDAD LEGAL PARA PARTICIPAR EN UN ACUERDO VINCULANTE]; 
+        Y (C) ACEPTA ESTE ACUERDO Y ASIENTE QUE USTED ESTÁ LEGALMENTE SUJETO A SUS TÉRMINOS. 
+        SI NO ACEPTA ESTOS TÉRMINOS, NO USE LA APLICACIÓN Y BÓRRELA DE SU DISPOSITIVO MÓVIL.
+    </p>
+    <ol>
+        <li>
+            <u>Concesión de licencia.</u> Sujeto a los términos de este Acuerdo, 
+            la Compañía le otorga una licencia limitada, no exclusiva e intransferible para:
+        </li>
+        <ol class="letteredOrdered">
+            <li>
+                descargar, instalar y utilizar la Aplicación para su uso personal y no 
+                comercial en un único dispositivo móvil que usted posea o de lo contrario 
+                controle ("Dispositivo móvil") estrictamente de conformidad con la 
+                documentación de la Aplicación.
+            </li>
+        </ol>
+        <li>
+            Restricciones de Licencia. El Licenciatario no deberá:
+        </li>
+        <ol class="letteredOrdered">
+            <li>
+                copiar la Aplicación, excepto lo expresamente permitido por esta licencia;
+            </li>
+            <li>
+                modificar, traducir, adaptar o de otro modo crear obras derivadas o mejoras, 
+                sean o no patentables, de la Aplicación;
+            </li>
+            <li>
+                realizar ingeniería inversa, desensamblar, descompilar, decodificar o de lo 
+                contrario intentar derivar u obtener acceso al código fuente de la Aplicación 
+                o cualquier parte de esta;
+            </li>
+            <li>
+                quitar, eliminar, alterar u ocultar cualquier marca registrada o derecho de 
+                autor, patente u otro aviso de derechos de propiedad intelectual o 
+                propiedad de la Aplicación, incluyendo cualquier copia de esta;
+            </li>
+            <li>
+                alquilar, arrendar, prestar, vender, sublicenciar, asignar, distribuir, 
+                publicar, transferir o poner a disposición la Aplicación, o cualquier 
+                característica o funcionalidad de la Aplicación, a cualquier tercero por 
+                cualquier motivo, incluso al facilitar la Aplicación en una red donde 
+                se pueda acceder con más de un dispositivo a la vez;
+            </li>
+            <li>
+                eliminar, deshabilitar, eludir o de otro modo crear o implementar cualquier 
+                solución alternativa a cualquier protección de copia, gestión de derechos 
+                o características de seguridad en o que proteja la Aplicación.
+            </li>
+        </ol>
+        <li>
+            <u>Reserva de derechos.</u> Usted reconoce y acepta que la Aplicación se proporciona bajo 
+            licencia y no se le vende. No adquiere ningún beneficio de propiedad en la 
+            Aplicación en virtud de este Acuerdo, ni ningún otro derecho que no sea el uso de 
+            la Aplicación de conformidad con la licencia otorgada, y sujeto a todos los términos, 
+            condiciones y restricciones de este Acuerdo. La Compañía se reserva y conservará 
+            todo su derecho, título y beneficios en y sobre la Aplicación, incluidos todos los 
+            derechos de autor, marcas comerciales y otros derechos de propiedad intelectual en esta 
+            o relacionados con ella, excepto lo expresamente otorgado a usted en este Acuerdo.
+        </li>
+        <li>
+            <u>Recopilación y uso de su información.</u> La Compañía no utiliza medios automáticos 
+            (incluidos, por ejemplo, cookies y web beacons) para recopilar información sobre su 
+            Dispositivo Móvil y sobre su uso de la Aplicación. Usted reconoce que la Aplicación 
+            puede brindarle oportunidades para compartir información sobre usted con otros. Toda 
+            la información relacionada con esta Aplicación está sujeta a nuestra Política de Privacidad. 
+            Al descargar, instalar, utilizar y proporcionar información a o través de esta Aplicación, 
+            usted acepta todas las acciones que tomamos con respecto a su información de conformidad con 
+            la Política de Privacidad.
+        </li>
+        <li>
+            <u>Actualizaciones.</u> De vez en cuando, la Compañía puede, a su exclusivo criterio, 
+            desarrollar y proporcionar actualizaciones de la Aplicación, que pueden incluir 
+            actualizaciones, correcciones de errores, parches, otras correcciones de errores y / o 
+            nuevas características (colectivamente, incluyendo la documentación relacionada, "Actualizaciones"). 
+            Las actualizaciones también pueden modificar o eliminar en su totalidad ciertas 
+            características y funcionalidades. Usted acepta que la Compañía no tiene la obligación 
+            de proporcionar Actualizaciones o continuar proporcionando o habilitando características 
+            o funcionalidades particulares. Según la configuración de su dispositivo móvil, 
+            cuando su dispositivo móvil está conectado a Internet:
+        </li>
+        <ol class="letteredOrdered">
+            <li>
+                la aplicación descargará e instalará automáticamente todas las 
+                actualizaciones disponibles;
+            </li>
+            <li>
+                es posible que reciba un aviso o se le solicite que descargue e instale 
+                las Actualizaciones disponibles.
+            </li>
+        </ol>
+        <p>
+            Deberá descargar e instalar rápidamente todas las Actualizaciones y reconocer 
+            y aceptar que la Aplicación o partes de esta pueden no funcionar correctamente 
+            si no lo hace. Además, acepta que todas las Actualizaciones se considerarán 
+            parte de la Aplicación y estarán sujetas a todos los términos y condiciones 
+            de este Acuerdo.
+        </p>
+        <li>
+            <u>Materiales de terceros.</u> La Aplicación puede mostrar, incluir o poner a disposición 
+            contenido de terceros (incluidos datos, información, aplicaciones y otros productos, 
+            servicios y / o materiales) o proporcionar enlaces a sitios web o servicios de 
+            terceros, incluso a través de publicidad de terceros. ("<strong>Materiales de terceros</strong>"). 
+            Usted reconoce y acepta que la Compañía no es responsable de los Materiales de terceros, 
+            incluida su precisión, integridad, oportunidad, validez, cumplimiento de los 
+            derechos de autor, legalidad, decencia, calidad o cualquier otro aspecto de estos. 
+            La compañía no asume y no tendrá ninguna responsabilidad u obligación hacia usted 
+            o cualquier otra persona o entidad por los Materiales de terceros. Los Materiales 
+            de terceros y los enlaces a los mismos se proporcionan únicamente para su conveniencia, 
+            y usted accede y los utiliza bajo su propio riesgo y sujeto a los términos y condiciones 
+            de dichos terceros.
+        </li>
+        <li>
+            <u>Entrada en vigor y rescisión.</u>
+            <ol class="letteredOrdered">
+                <li>
+                    El Acuerdo entra en vigor cuando usted [[descarga / instala] la Aplicación 
+                    / reconoce su aceptación] y continuará en vigencia hasta que usted o la 
+                    Compañía lo rescindan como se establece en esta Sección 7.
+                </li>
+                <li>
+                    Puede rescindir este Acuerdo eliminando la Aplicación 
+                    y todas sus copias de su Dispositivo Móvil.
+                </li>
+                <li>
+                    La Compañía puede rescindir este Acuerdo en cualquier 
+                    momento sin previo aviso si deja de respaldar la Aplicación, 
+                    lo que puede hacer a discreción. Además, este Acuerdo terminará 
+                    de manera inmediata y automática sin previo aviso si usted 
+                    viola alguno de los términos y condiciones de este Acuerdo.
+                </li>
+                <li>
+                    Al rescindirse:
+                    <ol class="romanOrdered">
+                        <li>
+                            todos los derechos otorgados a usted en virtud de este Acuerdo también finalizarán;
+                        </li>
+                        <li>
+                            debe dejar de usar la Aplicación y eliminar todas las copias de la Aplicación de su Dispositivo Móvil y cuenta.
+                        </li>
+                    </ol>
+                </li>
+                <li>
+                    La rescisión no limitará ninguno de los derechos o recursos de la Compañía por ley o equidad.
+                </li>
+            </ol>
+        </li>
+        <li>
+            <u>Descargo de responsabilidad de garantías.</u> LA APLICACIÓN SE PROPORCIONA AL LICENCIATARIO 
+            "TAL CUAL" Y CON TODAS LAS FALLAS Y DEFECTOS SIN GARANTÍA DE NINGÚN TIPO. EN LA MEDIDA 
+            QUE LO PERMITA LA LEY APLICABLE, LA COMPAÑÍA, EN NOMBRE PROPIO Y EN NOMBRE DE SUS AFILIADOS 
+            Y SUS RESPECTIVOS LICENCIANTES Y PROVEEDORES DE SERVICIOS, EXPRESAMENTE RECHAZA TODAS LAS 
+            GARANTÍAS, SEAN EXPRESAS, IMPLÍCITAS, LEGALES O RELACIONADAS CON LA APLICACIÓN, INCLUYENDO 
+            TODAS LAS GARANTÍAS IMPLÍCITAS DE COMERCIABILIDAD, UTILIDAD PARA UN FIN CONCRETO, TITULARIDAD 
+            Y NO INCUMPLIMIENTO, Y GARANTÍAS QUE PUEDEN SURGIR EN EL TRANSCURSO DEL TRATO, DESEMPEÑO, USO 
+            O PRÁCTICA COMERCIAL. SIN PERJUICIO DE LO ANTERIOR, LA COMPAÑÍA NO OFRECE NINGUNA GARANTÍA O 
+            COMPROMISO, Y NO HACE DECLARACIÓN ALGUNA DE NINGÚN TIPO DE QUE LA APLICACIÓN CUMPLIRÁ CON SUS 
+            REQUISITOS, LOGRARÁ NINGÚN RESULTADO PREVISTO, SERÁ COMPATIBLE O TRABAJARÁ CON CUALQUIER 
+            OTRO SOFTWARE, APLICACIONES, SISTEMAS O SERVICIOS, OPERARÁ SIN INTERRUPCIONES, CUMPLIRÁ CON 
+            NINGÚN ESTÁNDAR DE FUNCIONAMIENTO O CONFIABILIDAD, O ESTARÁ LIBRE DE ERRORES, O QUE CUALQUIER 
+            ERROR O DEFECTO PUEDE O PODRÁ SER CORREGIDO.
+        </li>
+        <P>
+            ALGUNAS JURISDICCIONES NO PERMITEN LA EXCLUSIÓN O LIMITACIONES DE LAS GARANTÍAS IMPLÍCITAS O 
+            LAS LIMITACIONES DE LOS DERECHOS LEGALES APLICABLES DE UN CONSUMIDOR, POR LO QUE ALGUNAS O 
+            TODAS LAS EXCLUSIONES Y LIMITACIONES ANTERIORES PUEDEN NO APLICARSE EN SU CASO.
+        </P>
+        <li>
+            Limitación de responsabilidad. EN LA MEDIDA QUE LO PERMITA LA LEY APLICABLE, EN NINGÚN 
+            CASO LA COMPAÑÍA O SUS AFILIADAS, O CUALQUIERA DE SUS RESPECTIVOS LICENCIADORES O 
+            PROVEEDORES DE SERVICIOS, TIENEN NINGUNA RESPONSABILIDAD DERIVADA O RELACIONADA CON SU 
+            USO O INCAPACIDAD DE UTILIZAR LA APLICACIÓN O EL CONTENIDO Y SERVICIOS PARA:
+            <ol class="letteredOrdered">
+                <li>
+                    LESIONES PERSONALES, DAÑOS A LA PROPIEDAD, GANANCIAS, PÉRDIDAS, COSTO DE BIENES 
+                    O SERVICIOS SUSTITUTOS, PÉRDIDA DE DATOS, PÉRDIDA DE PLUSVALÍA, INTERRUPCIÓN 
+                    EMPRESARIAL, FALLA COMPUTADORA O FALLA DE FUNCIONAMIENTO, O CUALQUIER OTRO 
+                    CONSECUENTE, INCIDENTAL, INDIRECTO, EJEMPLAR, ESPECIAL, O INDEMNIZACIÓN PUNITIVA.
+                </li>
+                <li>
+                    DAÑOS DIRECTOS EN CANTIDADES QUE EN TOTAL EXCEDEN EL MONTO REALMENTE PAGADO 
+                    POR USTED POR LA APLICACIÓN.
+                </li>
+            </ol>
+        </li>
+        <p>
+            LAS LIMITACIONES ANTERIORES SE APLICARÁN SI TALES DAÑOS SURGEN POR INCUMPLIMIENTO DE CONTRATO, 
+            TORTURA (INCLUYENDO NEGLIGENCIA), O DE OTRA MANERA Y SIN IMPORTAR SI DICHOS DAÑOS FUERON 
+            PREVISIBLES O LA COMPAÑÍA FUE INFORMADA DE LA POSIBILIDAD DE DICHOS DAÑOS. ALGUNAS JURISDICCIONES 
+            NO PERMITEN CIERTAS LIMITACIONES DE RESPONSABILIDAD, POR LO QUE ALGUNAS O TODAS LAS 
+            LIMITACIONES DE RESPONSABILIDAD ANTERIORES PUEDEN NO APLICARSE EN SU CASO.
+        </p>
+        <li>
+            <u>Indemnización.</u> Usted acepta indemnizar, defender y eximir de responsabilidad a la 
+            Compañía y sus funcionarios, directores, empleados, agentes, afiliados, sucesores y 
+            cesionarios de y contra todas y cada una de las pérdidas, daños, responsabilidades, deficiencias, 
+            reclamos, acciones, juicios, acuerdos, intereses. , premios, sanciones, multas, costos o gastos 
+            de cualquier tipo, incluidos los honorarios de abogados, derivados o relacionados con el uso o mal 
+            uso de la Aplicación o el incumplimiento de este Acuerdo, incluido, entre otros, el contenido 
+            que envíe o cree disponible a través de esta aplicación.
+        </li>
+        <li>
+            <u>Divisibilidad.</u> Si alguna disposición de este Acuerdo es ilegal o no ejecutable según la 
+            ley aplicable, el resto de la disposición se modificará para lograr el efecto más cercano posible 
+            del término original y todas las demás disposiciones de este Acuerdo continuarán en pleno vigor 
+            y efecto; sin embargo, siempre que algún término o disposición fundamental de este Acuerdo 
+            (incluyendo, entre otros, [TÉRMINOS FUNDAMENTALES APLICABLES]) sea inválido, ilegal o inaplicable, 
+            el resto de este Acuerdo será inaplicable.
+        </li>
+        <li>
+            <u>Ley aplicable.</u> Este Acuerdo se rige e interpreta de acuerdo con las leyes internas del 
+            Estado de Massachusetts sin dar efecto a ninguna disposición o regla de elección o conflicto 
+            de leyes. Cualquier demanda legal, acción o procedimiento que surja de o esté relacionado con 
+            este Acuerdo o la Aplicación se instituirá exclusivamente en los tribunales federales de los 
+            Estados Unidos o en los tribunales del Estado de Massachusetts, en cada caso ubicados en 
+            Somerville y el Condado de Middlesex. Usted renuncia a todas y cada una de las objeciones al 
+            ejercicio de la jurisdicción y competencia de dichos tribunales sobre usted.
+        </li>
+        <li>
+            <u>Prescripción.</u> CUALQUIER ACCIÓN O RECLAMACIÓN QUE USTED PUEDE FUNDAR O RELACIONAR CON 
+            ESTE ACUERDO O LA APLICACIÓN, DEBE INTRODUCIRSE DENTRO DE UN (1) AÑO, LUEGO DE GENERADA LA 
+            CAUSA, DE LO CONTRARIO ESTA ACCIÓN O RECLAMACIÓN PRESCRIBE.
+        </li>
+        <li>
+            <u>Acuerdo completo.</u> Este Acuerdo y nuestra Política de Privacidad constituyen el acuerdo 
+            completo entre usted y la Compañía con respecto a la Aplicación y reemplazan todos los 
+            entendimientos y acuerdos previos o contemporáneos, ya sean escritos u orales, con respecto 
+            a la Aplicación.
+        </li>
+        <li>
+            <u>Renuncia.</u>  Ningún incumplimiento o demora en el ejercicio, por parte de cualquiera de las partes, 
+            de cualquier derecho o poder en virtud del presente deberá operar como una renuncia al mismo, 
+            ni ningún ejercicio único o parcial de ningún derecho o poder en virtud del presente impedirá 
+            el ejercicio adicional de eso o cualquier otro derecho a continuación. En caso de conflicto 
+            entre este Acuerdo y cualquier compra aplicable u otros términos, regirán los términos 
+            de este Acuerdo.
+        </li>
+    </ol>
+  </body>
+</html>


### PR DESCRIPTION
#### Description:

Adding a Spanish version to the Terms of Use of the app

#### Linked issues:

[Related ticket](https://trello.com/c/OtqapT8i/147-incluir-las-pol%C3%ADticas-de-uso-de-usuarios)

#### Screenshots:

<img width="570" alt="Screen Shot 2020-06-11 at 12 11 07 PM" src="https://user-images.githubusercontent.com/57003769/84412077-b9685a00-abdc-11ea-8382-39247aff9c6c.png">

#### How to test:

Re-install the app if already installed to see the first onboarding page with the Terms of Use
