### PR TITLE
adding bulleting validation order

### DIFF
--- a/app/views/DR/News/Bulletins.js
+++ b/app/views/DR/News/Bulletins.js
@@ -38,7 +38,10 @@ export default function BulletinsScreen({ navigation }) {
   };
 
   const onPress = () => {
-    const { order } = bulletins[bulletins.length - 1] || {};
+    let { order } = bulletins[bulletins.length - 1] || {};
+    if (order === 67 && bulletins[bulletins.length - 2].order !== 66) {
+      order = bulletins[bulletins.length - 2].order;
+    }
     if (!order || order <= 10) {
       setIsNotLastPage(false);
       setIsDisable(true);


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Adding a validation to bulletins order

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
This fix is reference to this [PR](https://github.com/intellisysdcorp/covid-safe-paths/pull/95)

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- `git pull && git checkout Fix/pagination`
- Head over to bulletins screen and check that bulletins number 67 is not messing up the bulletins order