### PR TITLE
Remove touchableopacity for disable touch cards

### DIFF
--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -172,49 +172,42 @@ class HomeScreen extends Component {
                     </View>
                   </View>
                   <View style={styles.actualSituationContainer}>
-                    <TouchableOpacity>
-                      <Card style={styles.infoCards}>
-                        <Text style={[styles.dataText]}>{cases}</Text>
-                        <Text style={styles.text}>
-                          {t('label.positive_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
-                    <TouchableOpacity>
-                      <Card style={styles.infoCards}>
-                        <Text
-                          style={[
-                            styles.dataText,
-                            { color: Colors.BUTTON_LIGHT_TEX },
-                          ]}>
-                          {deaths}
-                        </Text>
-                        <Text style={styles.text}>
-                          {t('label.deceased_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
-                    <TouchableOpacity>
-                      <Card style={styles.infoCards}>
-                        <Text
-                          style={[styles.dataText, { color: Colors.GREEN }]}>
-                          {recovered}
-                        </Text>
-                        <Text style={styles.text}>
-                          {t('label.recovered_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
-                    <TouchableOpacity>
-                      <Card style={styles.infoCards}>
-                        <Text style={[styles.dataText, { color: Colors.SUN }]}>
-                          {todayCases}
-                        </Text>
-                        <Text style={styles.text}>
-                          {t('label.case_day_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
+                    <Card style={styles.infoCards}>
+                      <Text style={[styles.dataText]}>{cases}</Text>
+                      <Text style={styles.text}>
+                        {t('label.positive_label')}
+                      </Text>
+                    </Card>
+
+                    <Card style={styles.infoCards}>
+                      <Text
+                        style={[
+                          styles.dataText,
+                          { color: Colors.BUTTON_LIGHT_TEX },
+                        ]}>
+                        {deaths}
+                      </Text>
+                      <Text style={styles.text}>
+                        {t('label.deceased_label')}
+                      </Text>
+                    </Card>
+
+                    <Card style={styles.infoCards}>
+                      <Text style={[styles.dataText, { color: Colors.GREEN }]}>
+                        {recovered}
+                      </Text>
+                      <Text style={styles.text}>
+                        {t('label.recovered_label')}
+                      </Text>
+                    </Card>
+                    <Card style={styles.infoCards}>
+                      <Text style={[styles.dataText, { color: Colors.SUN }]}>
+                        {todayCases}
+                      </Text>
+                      <Text style={styles.text}>
+                        {t('label.case_day_label')}
+                      </Text>
+                    </Card>
                   </View>
                   <LocationMatch navigation={this.props.navigation} />
                   <Aurora navigation={this.props.navigation} />


### PR DESCRIPTION
#### Description:
Disable touch cards 
#### Linked issues:
[Fix#177](https://trello.com/c/CmygkRI6/177-hacer-que-los-cards-de-situación-actual-no-sean-clickable)
#### Screenshots:
![DisableCards](https://user-images.githubusercontent.com/51418416/85448704-f6c9d180-b564-11ea-88cf-595cf50bb550.PNG)

#### How to test:
