### PR TITLE
adjusting focus to news section

### DIFF
--- a/app/views/DR/News/Details.js
+++ b/app/views/DR/News/Details.js
@@ -31,12 +31,15 @@ const Details = ({
   };
 
   useEffect(() => {
-    BackHandler.addEventListener('hardwareBackPress', handleBackPress);
+    const unsubscribe = navigation.addListener('focus', () => {
+      BackHandler.addEventListener('hardwareBackPress', handleBackPress);
+    });
 
     return () => {
       BackHandler.removeEventListener('hardwareBackPress', handleBackPress);
+      unsubscribe;
     };
-  }, []);
+  }, [navigation]);
 
   return (
     <NavigationBarWrapper title='Atrás' onBackPress={backToMain.bind(this)}>


### PR DESCRIPTION

#### Description:

Fixing bulletins and advice pdf viewer

#### Linked issues:

[Related ticket](https://trello.com/c/2SDfBhiX/136-no-se-visualizan-los-boletines)

#### Screenshots:

<img width="569" alt="Screen Shot 2020-06-24 at 4 37 34 PM" src="https://user-images.githubusercontent.com/57003769/85625206-116d7a80-b639-11ea-8407-29b33f83e481.png">
<img width="569" alt="Screen Shot 2020-06-24 at 4 37 37 PM" src="https://user-images.githubusercontent.com/57003769/85625249-24804a80-b639-11ea-9dc3-d834d83eb410.png">


#### How to test:

- Go to the news section
- Go to bulletin section or advice section
- Open a file