### PR TITLE
adding phone number input to passport option

### DIFF
--- a/app/views/DR/UserInfoScreen/index.js
+++ b/app/views/DR/UserInfoScreen/index.js
@@ -171,6 +171,25 @@ export default function UserInfo({ navigation }) {
     return await validate(data);
   };
 
+  const isPassport = usePassport => {
+    if (usePassport) {
+      return (
+        <View>
+          <Text style={styles.textSemiBold}>
+            {t('report.userInfo.name_and_lastname')}
+          </Text>
+          <Input
+            value={passportName}
+            onChange={text => setSelectedOption('passportName', text)}
+            style={{ marginBottom: 12 }}
+            keyboardType={'default'}
+            maxLength={35}
+          />
+        </View>
+      );
+    }
+  };
+
   const setSelectedOption = (option, selected) => {
     setGlobalState({
       type: 'ADD_ANSWERS',
@@ -340,33 +359,19 @@ export default function UserInfo({ navigation }) {
                   />
                 )}
 
-                {usePassport ? (
-                  <View>
-                    <Text style={styles.textSemiBold}>
-                      {t('report.userInfo.name_and_lastname')}
-                    </Text>
-                    <Input
-                      value={passportName}
-                      onChange={text => setSelectedOption('passportName', text)}
-                      style={{ marginBottom: 12 }}
-                      keyboardType={'default'}
-                      maxLength={35}
-                    />
-                  </View>
-                ) : (
-                  <View>
-                    <Text style={styles.textSemiBold}>
-                      {t('report.userInfo.tel_number')}
-                    </Text>
-                    <PhoneInput
-                      value={phoneNumber}
-                      handleOnChange={text =>
-                        setSelectedOption('phoneNumber', text)
-                      }
-                      style={{ marginBottom: 12 }}
-                    />
-                  </View>
-                )}
+                {isPassport(usePassport)}
+
+                <Text style={styles.textSemiBold}>
+                  {t('report.userInfo.tel_number')}
+                </Text>
+                <PhoneInput
+                  value={phoneNumber}
+                  handleOnChange={text =>
+                    setSelectedOption('phoneNumber', text)
+                  }
+                  style={{ marginBottom: 12 }}
+                />
+
                 <Text style={[styles.textSemiBold, { marginBottom: 10 }]}>
                   {t('report.userInfo.birthdate')}
                 </Text>


### PR DESCRIPTION

#### Description:

Adding phone number input to passport option when choosing to fill the form.

#### Linked issues:

[Related ticket](https://trello.com/c/SRGAm3Xc/176-incluir-el-n%C3%BAmero-de-tel%C3%A9fono-al-form-de-pasaportes)

#### Screenshots:

<img width="570" alt="Screen Shot 2020-06-26 at 4 05 03 PM" src="https://user-images.githubusercontent.com/57003769/85896796-20823300-b7c7-11ea-899c-193fcb37d106.png">

#### How to test:

Go to report symptoms section
Open for myself or family member
Select the passport option 
