### PR TITLE
fixing margin in legal advice screen

### DIFF
--- a/app/views/Licenses.js
+++ b/app/views/Licenses.js
@@ -73,7 +73,7 @@ export const LicensesScreen = ({ navigation }) => {
       title={t('label.legal_page_title')}
       onBackPress={backToMain}>
       <ScrollView contentContainerStyle={styles.contentContainer}>
-        <View style={{ flex: 4 }}>
+        <View style={{ flex: 1 }}>
           <WebView
             originWhitelist={['*']}
             source={{
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     width: '100%',
     backgroundColor: Colors.INTRO_WHITE_BG,
-    paddingHorizontal: 26,
+    paddingHorizontal: 5,
     flex: 1,
   },
   termsInfoRow: {

--- a/app/views/Licenses.js
+++ b/app/views/Licenses.js
@@ -110,8 +110,8 @@ const styles = StyleSheet.create({
   contentContainer: {
     flexDirection: 'column',
     width: '100%',
-    backgroundColor: Colors.INTRO_WHITE_BG,
-    paddingHorizontal: 5,
+    backgroundColor: Colors.WHITE,
+    paddingHorizontal: 26,
     flex: 1,
   },
   termsInfoRow: {

--- a/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -95,7 +95,7 @@ exports[`renders correctly 1`] = `
     <RCTScrollView
       contentContainerStyle={
         Object {
-          "backgroundColor": "#F7F8FF",
+          "backgroundColor": "#FFF",
           "flex": 1,
           "flexDirection": "column",
           "paddingHorizontal": 26,
@@ -107,7 +107,7 @@ exports[`renders correctly 1`] = `
         <View
           style={
             Object {
-              "flex": 4,
+              "flex": 1,
             }
           }
         >


### PR DESCRIPTION

#### Description:

Fixing visual bug in Legal advice screen

#### Linked issues:

[Related ticket](https://trello.com/c/nZNzb5lR/205-screen-de-aviso-legal-fuera-de-margen)

#### Screenshots:

<img width="525" alt="Screen Shot 2020-07-13 at 11 10 42 AM" src="https://user-images.githubusercontent.com/57003769/87320893-8675f680-c4f9-11ea-8a06-16b8b9cf1965.png">


#### How to test:

Open the app
Go to settings
Choose legal advice
