### PR TITLE
fix label font-size and update snapshots

### DIFF
--- a/app/components/Button.js
+++ b/app/components/Button.js
@@ -74,7 +74,7 @@ const Container = styled.TouchableOpacity`
   align-self: stretch;
 `;
 
-const getFontSize = ({ small }) => (small ? '14px' : '20px');
+const getFontSize = ({ small }) => (small ? '18px' : '20px');
 
 const getLineHeight = ({ small }) => (small ? '21px' : '40px');
 

--- a/app/components/__tests__/__snapshots__/Button.spec.js.snap
+++ b/app/components/__tests__/__snapshots__/Button.spec.js.snap
@@ -43,7 +43,7 @@ exports[`allows small override 1`] = `
         Object {
           "color": "#FFF",
           "fontFamily": "IBMPlexSans-Medium",
-          "fontSize": 14,
+          "fontSize": 18,
           "fontWeight": "normal",
           "lineHeight": 21,
           "writingDirection": "ltr",

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -385,6 +385,7 @@ class LocationTracking extends Component {
     return (
       <Button
         label={buttonLabel}
+        small
         onPress={() => buttonFunction()}
         style={styles.buttonContainer}
       />
@@ -475,7 +476,7 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
   },
   buttonContainer: {
-    width: '100%',
+    width: 'auto',
     height: 'auto',
     marginTop: 24,
     minHeight: 54, // fixes overlaying buttons on really small screens


### PR DESCRIPTION

#### Description:

Fixing style of button in LocationTracking

#### Linked issues:

[Related ticket](https://trello.com/c/YoJc0xI0/207-modificar-el-estilo-del-boton-de-permitir-acceso-a-tu-ubicacion-en-el-idioma-espa%C3%B1ol)

#### Screenshots:

<img width="387" alt="Screen Shot 2020-07-13 at 4 44 26 PM" src="https://user-images.githubusercontent.com/57003769/87351883-22b6f200-c528-11ea-80bf-693e171c74f4.png">


#### How to test:

Open the app
Change language to spanish
Disable location in app
Open 'Comprobar contacto '
