### PR TITLE
Changed dialog wording for negatives

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -334,7 +334,7 @@
     },
     "userInfo": {
       "api_down_error_msg": "At this time we cannot validate your data. Please try again later.",
-      "is_not_positive_msg": "The identity card carrier has negative COVID.",
+      "is_not_positive_msg": "Dear user, your report will be validated with the results of the laboratories. Thank you for your collaboration to overcome this pandemic.",
       "incorrect_data_error_msg": "Incorrect data, please check.",
       "insert_data_title": "Enter your data",
       "insert_data_subtitle": "We will use these data to properly monitor your results:",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -157,7 +157,7 @@
     "privacy_policy": "Política de privacidad",
     "push_at_risk_message": "Has estado cerca de alguien con COVID-19",
     "push_at_risk_title": "Puedes estar en riesgo",
-    "recommendations_description": "Informate acerca del COVID-19, sus sintomas, preguntas frecuentes y medidas de prevencion.",
+    "recommendations_description": "Informate acerca del COVID-19, sus síntomas, preguntas frecuentes y medidas de prevencion.",
     "recommendations_title": "Recomendaciones",
     "recovered_label": "Recuperados",
     "report_symptoms_description": "Analizaremos tu estado actual de salud respecto al COVID-19 para darte instrucciones apropiadas para seguir",
@@ -321,16 +321,16 @@
     "usage": {
       "header_selector": "Selecciona lo que desea reportar",
       "header_subtitle": "Las siguientes preguntas están relacionadas con el COVID-19",
-      "selector": "Puede reportar si es COVID positivo o reportar sus sintomas actuales para saber algunos consejos",
+      "selector": "Puede reportar si es COVID positivo o reportar sus síntomas actuales para saber algunos consejos",
       "subtitle": "Responderás algunas preguntas sobre tus síntomas, viajes y el contacto que has tenido con otros",
       "positive_select": "Soy positivo",
-      "symptoms_select": "Reportar sintomas",
+      "symptoms_select": "Reportar síntomas",
       "use_myself": "Usar para mi",
       "use_others": "Usar para un familiar"
     },
     "userInfo": {
       "api_down_error_msg": "En estos momentos no podemos validar tus datos. Por favor intenta más tarde.",
-      "is_not_positive_msg": "El portador de la cedula ha resultado COVID negativo.",
+      "is_not_positive_msg": "Estimado usuario, su reporte será validado con los resultados de los laboratorios. Gracias por tu colaboración para entre todos vencer a esta pandemia.",
       "incorrect_data_error_msg": "Datos incorrectos, por favor revise.",
       "insert_data_title": "Ingrese sus datos",
       "insert_data_subtitle": "Utilizaremos estos datos para darle el apropiado seguimiento a sus resultados:",


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
Changed the wording for negatives ID's in positive report, as shown in the screenshots
<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues:
[Ticket 210](https://trello.com/c/vvtlsPx3/210-cambiar-el-wording-para-los-resultados-de-c%C3%A9dulas-negativos)
<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:
![Simulator Screen Shot - iPhone 11 - 2020-07-16 at 11 29 37](https://user-images.githubusercontent.com/56127045/87691286-6ee87900-c758-11ea-9c82-b05220b8db28.png)
![Simulator Screen Shot - iPhone 11 - 2020-07-16 at 11 27 48](https://user-images.githubusercontent.com/56127045/87691288-6f810f80-c758-11ea-88ae-895515878a99.png)

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
