### PR TITLE
Fixing language bug in Terms and conditions and Date roll in Exposure History

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -42,14 +42,14 @@ class Entry extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      initialRouteName: 'true',
+      initialRouteName: null,
     };
   }
 
   async componentDidMount() {
-    let onboardingDoneName = await GetStoreData('ONBOARDING_DONE');
-    this.setState({
-      initialRouteName: onboardingDoneName,
+    GetStoreData('ONBOARDING_DONE').then(onboardingDoneName => {
+      this.setState({ initialRouteName: onboardingDoneName });
+      console.log(onboardingDoneName, 'thissss');
     });
   }
 

--- a/app/Entry.js
+++ b/app/Entry.js
@@ -47,10 +47,9 @@ class Entry extends Component {
   }
 
   async componentDidMount() {
-    GetStoreData('ONBOARDING_DONE').then(onboardingDoneName => {
-      this.setState({ initialRouteName: onboardingDoneName });
-      console.log(onboardingDoneName, 'thissss');
-    });
+    GetStoreData('ONBOARDING_DONE').then(onboardingDoneName =>
+      this.setState({ initialRouteName: onboardingDoneName }),
+    );
   }
 
   render() {

--- a/app/Entry.js
+++ b/app/Entry.js
@@ -46,7 +46,7 @@ class Entry extends Component {
     };
   }
 
-  async componentDidMount() {
+   componentDidMount() {
     GetStoreData('ONBOARDING_DONE').then(onboardingDoneName =>
       this.setState({ initialRouteName: onboardingDoneName }),
     );

--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -109,9 +109,9 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
                       : Colors.LIGHT_GRAY,
                   }}
                   disabled={!canContinue}
-                  onPress={() => {
+                  onPress={async () => {
                     setModalVisibility(false);
-                    continueFunction();
+                    await continueFunction();
                   }}>
                   <Text
                     style={{

--- a/app/views/ExposureHistory/MonthGrid.js
+++ b/app/views/ExposureHistory/MonthGrid.js
@@ -42,14 +42,19 @@ export const MonthGrid = ({
     throw new Error('renderDay and renderDayHeader are required');
   }
 
+  const locale = dayjs.locale();
   const headers = dayjs.localeData().weekdaysShort(); // 'mon', 'tue', ...
 
   const start = date
     .startOf('day')
     .startOf('week')
+    .subtract(locale !== 'en' && 1, 'day')
     .subtract(weeks - 1, 'week');
 
-  const end = date.startOf('day').endOf('week');
+  const end = date
+    .startOf('day')
+    .endOf('week')
+    .subtract(locale !== 'en' && 1, 'day');
 
   /** @type {dayjs.Dayjs[]} */
   const days = daysBetween(start, end, 'day');

--- a/app/views/onboarding/Onboarding1.js
+++ b/app/views/onboarding/Onboarding1.js
@@ -21,7 +21,9 @@ import NativePicker from '../../components/NativePicker';
 import { Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
 import fontFamily from '../../constants/fonts';
+import { LANG_OVERRIDE } from '../../constants/storage';
 import { Theme } from '../../constants/themes';
+import { SetStoreData } from '../../helpers/General';
 import { sharedStyles } from './styles';
 
 const width = Dimensions.get('window').width;
@@ -101,9 +103,10 @@ class Onboarding extends Component {
               </View>
               <View style={sharedStyles.footerContainer}>
                 <EulaModal
-                  continueFunction={() =>
-                    this.props.navigation.replace('Onboarding2')
-                  }
+                  continueFunction={async () => {
+                    this.props.navigation.replace('Onboarding2');
+                    await SetStoreData(LANG_OVERRIDE, this.state.locale);
+                  }}
                   selectedLocale={this.state.locale}
                 />
               </View>


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
Sometimes the language do not match with the app and the content, specifically in Terms and Conditions, and the exposure history Calendar has a date roll when not in english. This PR fix that
<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues:
[Ticket 219](https://trello.com/c/fQrJ7aAu/219-some-devices-shows-t%C3%A9rminos-y-condiciones-en-ingl%C3%A9s-3)
[Ticket 230](https://trello.com/c/TfglD1Fq/230-calendario-de-historial-de-exposici%C3%B3n-est%C3%A1-retrasado-por-un-d%C3%ADa)
<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:
Check in Spanish if the Terms & Conditions are in the selected Language and in Exposure History if the date matches correctly.
<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
