### PR TITLE
Change icons in Bulletins and Advices

### DIFF
--- a/app/components/DR/List.js
+++ b/app/components/DR/List.js
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import { widthPercentageToDP as wp } from 'react-native-responsive-screen';
+import Icon from 'react-native-vector-icons/FontAwesome5';
 
 import fontFamily from '../../constants/fonts';
 
@@ -28,7 +29,7 @@ export default function DataList({
         (
           {
             url = '#',
-            img: { source },
+            icon: { iconName },
             title = '',
             dateLabel = '',
             content = '',
@@ -44,7 +45,8 @@ export default function DataList({
             }
             key={String(index)}
             style={styles.itemContainer}>
-            <Image style={styles.image} source={source} />
+            <Icon name={iconName} size={30} color='#000' />
+            {/* <Image style={styles.image} source={source} /> */}
             <View style={styles.right}>
               <Text
                 numberOfLines={titleLinesNum}

--- a/app/components/DR/List.js
+++ b/app/components/DR/List.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   ActivityIndicator,
-  Image,
   StyleSheet,
   Text,
   TouchableOpacity,

--- a/app/components/DR/List.js
+++ b/app/components/DR/List.js
@@ -29,7 +29,7 @@ export default function DataList({
         (
           {
             url = '#',
-            icon: { iconName },
+            icon: { iconName, color },
             title = '',
             dateLabel = '',
             content = '',
@@ -45,8 +45,12 @@ export default function DataList({
             }
             key={String(index)}
             style={styles.itemContainer}>
-            <Icon name={iconName} size={30} color='#000' />
-            {/* <Image style={styles.image} source={source} /> */}
+            <Icon
+              name={iconName}
+              size={30}
+              color={color}
+              style={{ marginLeft: 10 }}
+            />
             <View style={styles.right}>
               <Text
                 numberOfLines={titleLinesNum}

--- a/app/views/DR/News/Advices.js
+++ b/app/views/DR/News/Advices.js
@@ -11,7 +11,7 @@ import languages from '../../../locales/languages';
 export default function Advices({ navigation }) {
   const recommendationData = data.map(item => ({
     ...item,
-    img: { source: iconAdvertisement },
+    icon: { iconName: 'comment-medical' },
   }));
 
   return (

--- a/app/views/DR/News/Advices.js
+++ b/app/views/DR/News/Advices.js
@@ -5,13 +5,14 @@ import iconAdvertisement from '../../../assets/images/idea.jpg';
 import imgAdvertisement from '../../../assets/images/recommendations.jpg';
 import HeaderImage from '../../../components/DR/HeaderImage';
 import List from '../../../components/DR/List';
+import Colors from '../../../constants/colors-dr';
 import data from '../../../constants/DR/RecommendationData';
 import languages from '../../../locales/languages';
 
 export default function Advices({ navigation }) {
   const recommendationData = data.map(item => ({
     ...item,
-    icon: { iconName: 'comment-medical' },
+    icon: { iconName: 'comment-medical', color: Colors.PINK },
   }));
 
   return (

--- a/app/views/DR/News/Bulletins.js
+++ b/app/views/DR/News/Bulletins.js
@@ -12,6 +12,7 @@ import {
 import imgBulletins from '../../../assets/images/bulletins.jpg';
 import HeaderImage from '../../../components/DR/ActionCards/HeaderImage';
 import List from '../../../components/DR/List';
+import Colors from '../../../constants/colors-dr';
 import { FIREBASE_SERVICE } from '../../../constants/DR/baseUrls';
 import buttonStyle from '../../../constants/DR/buttonStyles';
 import fetch from '../../../helpers/Fetch';
@@ -32,7 +33,7 @@ export default function BulletinsScreen({ navigation }) {
   const addImgToBulletin = bulletinList => {
     return bulletinList.map(item => ({
       ...item,
-      icon: { iconName: 'copy' },
+      icon: { iconName: 'copy', color: Colors.BLUE_RIBBON },
     }));
   };
 

--- a/app/views/DR/News/Bulletins.js
+++ b/app/views/DR/News/Bulletins.js
@@ -9,10 +9,9 @@ import {
   View,
 } from 'react-native';
 
-import iconImgBulletin from '../../../assets/images/bulletin.jpg';
 import imgBulletins from '../../../assets/images/bulletins.jpg';
 import HeaderImage from '../../../components/DR/ActionCards/HeaderImage';
-import List from '../../../components/DR/ActionCards/List';
+import List from '../../../components/DR/List';
 import { FIREBASE_SERVICE } from '../../../constants/DR/baseUrls';
 import buttonStyle from '../../../constants/DR/buttonStyles';
 import fetch from '../../../helpers/Fetch';
@@ -33,7 +32,7 @@ export default function BulletinsScreen({ navigation }) {
   const addImgToBulletin = bulletinList => {
     return bulletinList.map(item => ({
       ...item,
-      img: { source: iconImgBulletin },
+      icon: { iconName: 'copy' },
     }));
   };
 


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
This PR changes the icons of advices and bulletins, for a better look.
<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:
![Simulator Screen Shot - iPhone 11 - 2020-07-24 at 00 06 43](https://user-images.githubusercontent.com/56127045/88396617-c8702980-cd90-11ea-90db-73d372ca9766.png)
![Simulator Screen Shot - iPhone 11 - 2020-07-24 at 00 06 47](https://user-images.githubusercontent.com/56127045/88396626-cad28380-cd90-11ea-9ef3-f0d24cb1dac4.png)

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
