### PR TITLE
Feat: notified new subscription ones

### DIFF
--- a/app/services/HCAService.js
+++ b/app/services/HCAService.js
@@ -192,10 +192,20 @@ class HCAService {
    * @returns {void}
    */
   async pushAlertNewSubscribedAuthorities(count) {
-    await PushNotification.localNotification({
-      title: languages.t('label.authorities_new_subscription_title', { count }),
-      message: languages.t('label.authorities_new_subscription_msg', { count }),
-    });
+    const notifiedNewSubs = await GetStoreData('notifiedNewAuthSubscription');
+
+    if (!notifiedNewSubs) {
+      await SetStoreData('notifiedNewAuthSubscription', true);
+
+      await PushNotification.localNotification({
+        title: languages.t('label.authorities_new_subscription_title', {
+          count,
+        }),
+        message: languages.t('label.authorities_new_subscription_msg', {
+          count,
+        }),
+      });
+    }
   }
 
   /**

--- a/jest/setupFile.js
+++ b/jest/setupFile.js
@@ -13,6 +13,7 @@ NativeModules.SecureStorageManager = NativeModules.SecureStorageManager || {
   migrateExistingLocations: jest.fn(),
 };
 
+jest.mock('react-native-version-check');
 jest.mock('react-native-pulse');
 jest.mock('@mauron85/react-native-background-geolocation');
 jest.mock('react-native-location', () => ({


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Adding a validation whether the user have been notified about Subscription to a Health Authority, in case that was, it will not notify again otherwise will be notify
#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
Fix: [240](https://trello.com/c/vHdtlFqp/240-permitir-notificaci%C3%B3n-de-suscripci%C3%B3n-a-una-autoridad-de-salud-una-sola-vez-1)
#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- `git pull && git checkout Feat/240-notified-new-subscription-ones`
- Open the app
- you should receive notification of subscription to a new health authority only once