### PR TITLE
Feat: Add webview in cards of dashboard

### DIFF
--- a/app/views/DR/HomeScreen/DashboardCards.js
+++ b/app/views/DR/HomeScreen/DashboardCards.js
@@ -5,7 +5,7 @@ import { TouchableOpacity } from 'react-native';
 import Colors from '../../../constants/colors';
 import styles from './style';
 
-export default function dashboardCards({
+export default function DashboardCards({
   navigation,
   t,
   confirmed,

--- a/app/views/DR/HomeScreen/DashboardCards.js
+++ b/app/views/DR/HomeScreen/DashboardCards.js
@@ -34,7 +34,7 @@ export default function DashboardCards({
   const CONFIRMED_COVID_CASES_URL =
     'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
 
-  return dashboardCategories.map((obj, index) => (
+  return dashboardCategories.map(obj => (
     <TouchableOpacity
       style={styles.shadowBorder}
       key={obj.label}

--- a/app/views/DR/HomeScreen/DashboardCards.js
+++ b/app/views/DR/HomeScreen/DashboardCards.js
@@ -1,0 +1,52 @@
+import { Card, Text } from 'native-base';
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+
+import Colors from '../../../constants/colors';
+import styles from './style';
+
+export default function dashboardCards({
+  navigation,
+  t,
+  confirmed,
+  deaths,
+  recovered,
+  current,
+}) {
+  const dashboardCategories = [
+    { label: 'label.positive_label', styles: '', value: confirmed },
+    {
+      label: 'label.deceased_label',
+      styles: { color: Colors.BUTTON_LIGHT_TEX },
+      value: deaths,
+    },
+    {
+      label: 'label.recovered_label',
+      styles: { color: Colors.GREEN },
+      value: recovered,
+    },
+    {
+      label: 'label.case_day_label',
+      styles: { color: Colors.SUN },
+      value: current,
+    },
+  ];
+  const CONFIRMED_COVID_CASES_URL =
+    'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
+
+  return dashboardCategories.map((obj, index) => (
+    <TouchableOpacity
+      style={styles.shadowBorder}
+      key={index}
+      onPress={() =>
+        navigation.navigate('Details', {
+          source: { uri: CONFIRMED_COVID_CASES_URL },
+        })
+      }>
+      <Card style={styles.infoCards}>
+        <Text style={[styles.dataText, obj.styles]}>{obj.value}</Text>
+        <Text style={styles.text}>{t(obj.label)}</Text>
+      </Card>
+    </TouchableOpacity>
+  ));
+}

--- a/app/views/DR/HomeScreen/DashboardCards.js
+++ b/app/views/DR/HomeScreen/DashboardCards.js
@@ -37,7 +37,7 @@ export default function DashboardCards({
   return dashboardCategories.map((obj, index) => (
     <TouchableOpacity
       style={styles.shadowBorder}
-      key={index}
+      key={obj.label}
       onPress={() =>
         navigation.navigate('Details', {
           source: { uri: CONFIRMED_COVID_CASES_URL },

--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -187,8 +187,8 @@ class HomeScreen extends Component {
       const CONFIRMED_COVID_CASES_URL =
         'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
 
-      return dashboardCategories.map(obj => {
-        return (
+      return dashboardCategories.map(obj => 
+         (
           <TouchableOpacity
             style={styles.shadowBorder}
             key={Index}

--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -29,6 +29,7 @@ import fetch from '../../../helpers/Fetch';
 import { GetStoreData, SetStoreData } from '../../../helpers/General';
 import { getAllCases } from '../../../services/DR/getAllCases.js';
 import DialogAdvice from '../../DialogAdvices';
+import Index from '../Sponsors';
 import styles from './style';
 
 class HomeScreen extends Component {
@@ -164,9 +165,45 @@ class HomeScreen extends Component {
       state: { confirmed, deaths, recovered, current, refreshing, notified },
     } = this;
 
-    const getUrlMap = () => {
-      const url = 'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
-      return navigation.navigate('Details', { source: { uri: url } });
+    const dashboardCards = () => {
+      const dashboardCategories = [
+        { label: 'label.positive_label', styles: '', value: confirmed },
+        {
+          label: 'label.deceased_label',
+          styles: { color: Colors.BUTTON_LIGHT_TEX },
+          value: deaths,
+        },
+        {
+          label: 'label.recovered_label',
+          styles: { color: Colors.GREEN },
+          value: recovered,
+        },
+        {
+          label: 'label.case_day_label',
+          styles: { color: Colors.SUN },
+          value: current,
+        },
+      ];
+      const CONFIRMED_COVID_CASES_URL =
+        'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
+
+      return dashboardCategories.map(obj => {
+        return (
+          <TouchableOpacity
+            style={styles.shadowBorder}
+            key={Index}
+            onPress={() =>
+              navigation.navigate('Details', {
+                source: { uri: CONFIRMED_COVID_CASES_URL },
+              })
+            }>
+            <Card style={styles.infoCards}>
+              <Text style={[styles.dataText, obj.styles]}>{obj.value}</Text>
+              <Text style={styles.text}>{t(obj.label)}</Text>
+            </Card>
+          </TouchableOpacity>
+        );
+      });
     };
     return (
       <SafeAreaView style={{ flex: 1 }}>
@@ -213,60 +250,7 @@ class HomeScreen extends Component {
                     </View>
                   </View>
                   <View style={styles.actualSituationContainer}>
-                    <TouchableOpacity
-                      style={styles.shadowBorder}
-                      onPress={() => getUrlMap()}>
-                      <Card style={styles.infoCards}>
-                        <Text style={[styles.dataText]}>{confirmed}</Text>
-                        <Text style={styles.text}>
-                          {t('label.positive_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
-
-                    <TouchableOpacity
-                      style={styles.shadowBorder}
-                      onPress={() => getUrlMap()}>
-                      <Card style={styles.infoCards}>
-                        <Text
-                          style={[
-                            styles.dataText,
-                            { color: Colors.BUTTON_LIGHT_TEX },
-                          ]}>
-                          {deaths}
-                        </Text>
-                        <Text style={styles.text}>
-                          {t('label.deceased_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
-
-                    <TouchableOpacity
-                      style={styles.shadowBorder}
-                      onPress={() => getUrlMap()}>
-                      <Card style={styles.infoCards}>
-                        <Text
-                          style={[styles.dataText, { color: Colors.GREEN }]}>
-                          {recovered}
-                        </Text>
-                        <Text style={styles.text}>
-                          {t('label.recovered_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
-
-                    <TouchableOpacity
-                      style={styles.shadowBorder}
-                      onPress={() => getUrlMap()}>
-                      <Card style={styles.infoCards}>
-                        <Text style={[styles.dataText, { color: Colors.SUN }]}>
-                          {current}
-                        </Text>
-                        <Text style={styles.text}>
-                          {t('label.case_day_label')}
-                        </Text>
-                      </Card>
-                    </TouchableOpacity>
+                    {dashboardCards()}
                   </View>
                   <LocationMatch navigation={this.props.navigation} />
                   <Aurora navigation={this.props.navigation} />

--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -1,7 +1,7 @@
 import 'moment/locale/es';
 
 import moment from 'moment';
-import { Button, Card, Left, Text } from 'native-base';
+import { Button, Left, Text } from 'native-base';
 import React, { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import {
@@ -29,7 +29,7 @@ import fetch from '../../../helpers/Fetch';
 import { GetStoreData, SetStoreData } from '../../../helpers/General';
 import { getAllCases } from '../../../services/DR/getAllCases.js';
 import DialogAdvice from '../../DialogAdvices';
-import Index from '../Sponsors';
+import DashboardCards from './DashboardCards';
 import styles from './style';
 
 class HomeScreen extends Component {
@@ -165,46 +165,6 @@ class HomeScreen extends Component {
       state: { confirmed, deaths, recovered, current, refreshing, notified },
     } = this;
 
-    const dashboardCards = () => {
-      const dashboardCategories = [
-        { label: 'label.positive_label', styles: '', value: confirmed },
-        {
-          label: 'label.deceased_label',
-          styles: { color: Colors.BUTTON_LIGHT_TEX },
-          value: deaths,
-        },
-        {
-          label: 'label.recovered_label',
-          styles: { color: Colors.GREEN },
-          value: recovered,
-        },
-        {
-          label: 'label.case_day_label',
-          styles: { color: Colors.SUN },
-          value: current,
-        },
-      ];
-      const CONFIRMED_COVID_CASES_URL =
-        'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
-
-      return dashboardCategories.map(obj => 
-         (
-          <TouchableOpacity
-            style={styles.shadowBorder}
-            key={Index}
-            onPress={() =>
-              navigation.navigate('Details', {
-                source: { uri: CONFIRMED_COVID_CASES_URL },
-              })
-            }>
-            <Card style={styles.infoCards}>
-              <Text style={[styles.dataText, obj.styles]}>{obj.value}</Text>
-              <Text style={styles.text}>{t(obj.label)}</Text>
-            </Card>
-          </TouchableOpacity>
-        );
-      });
-    };
     return (
       <SafeAreaView style={{ flex: 1 }}>
         <View style={{ flex: 1, backgroundColor: Colors.BLUE_RIBBON }}>
@@ -250,7 +210,14 @@ class HomeScreen extends Component {
                     </View>
                   </View>
                   <View style={styles.actualSituationContainer}>
-                    {dashboardCards()}
+                    <DashboardCards
+                      t={t}
+                      navigation={navigation}
+                      confirmed={confirmed}
+                      deaths={deaths}
+                      recovered={recovered}
+                      current={current}
+                    />
                   </View>
                   <LocationMatch navigation={this.props.navigation} />
                   <Aurora navigation={this.props.navigation} />

--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -164,6 +164,10 @@ class HomeScreen extends Component {
       state: { confirmed, deaths, recovered, current, refreshing, notified },
     } = this;
 
+    const getUrlMap = () => {
+      const url = 'https://coronavirusrd.gob.do/casos-de-covid-19-confirmados/';
+      return navigation.navigate('Details', { source: { uri: url } });
+    };
     return (
       <SafeAreaView style={{ flex: 1 }}>
         <View style={{ flex: 1, backgroundColor: Colors.BLUE_RIBBON }}>
@@ -209,42 +213,60 @@ class HomeScreen extends Component {
                     </View>
                   </View>
                   <View style={styles.actualSituationContainer}>
-                    <Card style={styles.infoCards}>
-                      <Text style={[styles.dataText]}>{confirmed}</Text>
-                      <Text style={styles.text}>
-                        {t('label.positive_label')}
-                      </Text>
-                    </Card>
+                    <TouchableOpacity
+                      style={styles.shadowBorder}
+                      onPress={() => getUrlMap()}>
+                      <Card style={styles.infoCards}>
+                        <Text style={[styles.dataText]}>{confirmed}</Text>
+                        <Text style={styles.text}>
+                          {t('label.positive_label')}
+                        </Text>
+                      </Card>
+                    </TouchableOpacity>
 
-                    <Card style={styles.infoCards}>
-                      <Text
-                        style={[
-                          styles.dataText,
-                          { color: Colors.BUTTON_LIGHT_TEX },
-                        ]}>
-                        {deaths}
-                      </Text>
-                      <Text style={styles.text}>
-                        {t('label.deceased_label')}
-                      </Text>
-                    </Card>
+                    <TouchableOpacity
+                      style={styles.shadowBorder}
+                      onPress={() => getUrlMap()}>
+                      <Card style={styles.infoCards}>
+                        <Text
+                          style={[
+                            styles.dataText,
+                            { color: Colors.BUTTON_LIGHT_TEX },
+                          ]}>
+                          {deaths}
+                        </Text>
+                        <Text style={styles.text}>
+                          {t('label.deceased_label')}
+                        </Text>
+                      </Card>
+                    </TouchableOpacity>
 
-                    <Card style={styles.infoCards}>
-                      <Text style={[styles.dataText, { color: Colors.GREEN }]}>
-                        {recovered}
-                      </Text>
-                      <Text style={styles.text}>
-                        {t('label.recovered_label')}
-                      </Text>
-                    </Card>
-                    <Card style={styles.infoCards}>
-                      <Text style={[styles.dataText, { color: Colors.SUN }]}>
-                        {current}
-                      </Text>
-                      <Text style={styles.text}>
-                        {t('label.case_day_label')}
-                      </Text>
-                    </Card>
+                    <TouchableOpacity
+                      style={styles.shadowBorder}
+                      onPress={() => getUrlMap()}>
+                      <Card style={styles.infoCards}>
+                        <Text
+                          style={[styles.dataText, { color: Colors.GREEN }]}>
+                          {recovered}
+                        </Text>
+                        <Text style={styles.text}>
+                          {t('label.recovered_label')}
+                        </Text>
+                      </Card>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                      style={styles.shadowBorder}
+                      onPress={() => getUrlMap()}>
+                      <Card style={styles.infoCards}>
+                        <Text style={[styles.dataText, { color: Colors.SUN }]}>
+                          {current}
+                        </Text>
+                        <Text style={styles.text}>
+                          {t('label.case_day_label')}
+                        </Text>
+                      </Card>
+                    </TouchableOpacity>
                   </View>
                   <LocationMatch navigation={this.props.navigation} />
                   <Aurora navigation={this.props.navigation} />

--- a/app/views/DR/HomeScreen/style.js
+++ b/app/views/DR/HomeScreen/style.js
@@ -88,6 +88,16 @@ const styles = StyleSheet.create({
   dateSubtitle: {
     color: '#808080',
   },
+  shadowBorder: {
+    color: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
 });
 
 export default styles;


### PR DESCRIPTION
#### Description:
A link was added on the board, the same for each card, in which it directs you to a page with the cases of the covid of the country and its provinces
#### Linked issues:

[Ticket #252](https://trello.com/c/NonM37GZ/252-as-a-user-i-want-to-see-a-map-when-on-click-in-the-dashboard-cards-so-that-i-can-consult-the-cases-by-provinces-1)

#### Screenshots:
![Captura](https://user-images.githubusercontent.com/51418416/89821874-4b2d0e80-db1d-11ea-8664-e5cde1092780.PNG)
#### How to test:

In Home Screen all cards touch and redirect to the webview