### PR TITLE
Change the Done button color for a more intuitive one

### DIFF
--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -69,7 +69,7 @@ const colors = {
   MONO_SECONDARY: '#757677',
 
   BLUE_RIBBON: '#0161F2',
-  BLUE_DISABLED: '#658bc2',
+  BLUE_DISABLED: '#bdc3c7',
   LIGHT_BLUE: '#EFF4F9',
   DOVE_GRAY: '#6B6B6B',
   SUN: '#FEB313',


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
Changed the disabled color of the button for one that looks more like a disabled button in the Positives onboarding screen.
<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues:
[Ticket 270](https://trello.com/c/GI0bBkTQ/270-cambiar-los-colores-para-el-boton-de-desactivado-y-activado-del-nick-1)

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:
![Simulator Screen Shot - iPhone 11 - 2020-09-08 at 09 20 46](https://user-images.githubusercontent.com/56127045/92481969-13b19080-f1b5-11ea-80dc-59e82f04f0e2.png)
![Simulator Screen Shot - iPhone 11 - 2020-09-08 at 09 20 54](https://user-images.githubusercontent.com/56127045/92481972-14e2bd80-f1b5-11ea-9d8f-0864ed57f6b2.png)

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:
Navigate to the positive onboarding screen, through a positive ID Card validation, and see the behavior of the "Done" button in that screen
<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
