### PR TITLE
Fix: way news take the last img

### DIFF
--- a/app/components/DR/List.js
+++ b/app/components/DR/List.js
@@ -37,7 +37,9 @@ export default function DataList({
     if (img.source) return img.source;
 
     const firstCropFound = crops.find(cropName => img[cropName]);
-    return firstCropFound ? { uri: img[firstCropFound] } : { uri: img.master };
+    return firstCropFound
+      ? { uri: img[firstCropFound] }
+      : { uri: Object.values(img)[0] };
   };
 
   if (data.length === 0) return <ActivityIndicator size='large' />;


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
There used to be a default image called master in every news object, but no anymore that's why some of then were showed without one, so to every object that does not match the crops name it will take the default image it has
#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
Fix: [279](https://trello.com/c/Du0VWdlZ/279-as-a-user-i-want-to-see-a-default-icon-for-news-so-that-i-can-see-a-related-image-to-the-article-for-reading)
#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
![image](https://user-images.githubusercontent.com/43874147/93647363-425e1100-f9d6-11ea-8982-6ae08e899fb1.png)

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- `git pull && git checkout Fix/279-refactoring-way-news-take-img`
- Head over to news section
- You should see that every block of news has a image