### PR TITLE
Fix: Report and register covid user

### DIFF
--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -61,11 +61,11 @@ class HomeScreen extends Component {
       );
       if (covidId && !haveBeenNotified) {
         this.filterState(userList);
-        const { use, name = 'Usted', positive } = userList.find(
+        const { use, name = 'Usted' } = userList.find(
           user => user.covidId === covidId,
         );
 
-        saveUserState({ covidId, positive, haveBeenNotified: true });
+        saveUserState({ covidId, haveBeenNotified: true });
         this.setState({
           notified: true,
           useType: use,

--- a/app/views/DR/HomeScreen/index.js
+++ b/app/views/DR/HomeScreen/index.js
@@ -43,29 +43,36 @@ class HomeScreen extends Component {
     };
   }
 
-  filterState = async userList => {
+  filterState = async (userList, userCovidId) => {
     const filterUserList = userList.filter(user => user.covidId !== undefined);
-    await SetStoreData('users', filterUserList);
+    const userListConvert = filterUserList.map(user =>
+      user.covidId === userCovidId ? { ...user, positive: true } : user,
+    );
+
+    await SetStoreData('users', userListConvert);
   };
 
-  handler = userList => {
+  setAndGetUserState = userList => {
     const promiseList = userList.map(userState => {
       return fetch(`${FIREBASE_SERVICE}/covid-state/${userState.covidId}`);
     });
 
     Promise.all(promiseList).then(state => {
-      const {
-        data: { covidId = false, haveBeenNotified = false },
-      } = state.find(
+      const negativeUserToPositive = state.find(
         ({ data }) => data.positive === true && data.haveBeenNotified === false,
       );
-      if (covidId && !haveBeenNotified) {
-        this.filterState(userList);
+
+      if (negativeUserToPositive) {
+        const {
+          data: { covidId },
+        } = negativeUserToPositive;
+
+        this.filterState(userList, covidId);
         const { use, name = 'Usted' } = userList.find(
           user => user.covidId === covidId,
         );
 
-        saveUserState({ covidId, haveBeenNotified: true });
+        saveUserState({ covidId, positive: true, haveBeenNotified: true });
         this.setState({
           notified: true,
           useType: use,
@@ -107,12 +114,14 @@ class HomeScreen extends Component {
     const covidIdList = await GetStoreData('covidIdList', false);
     let userList = await GetStoreData('users', false);
 
-    if (covidIdList !== null) {
-      userList = userList.concat(covidIdList);
-      RemoveStoreData(covidIdList);
-      this.handler(userList);
-    } else {
-      this.handler(userList);
+    if (userList) {
+      if (covidIdList) {
+        userList = userList.concat(covidIdList);
+        RemoveStoreData(covidIdList);
+        this.setAndGetUserState(userList);
+      } else {
+        this.setAndGetUserState(userList);
+      }
     }
   }
 

--- a/app/views/DR/ReportScreen/ReportType.js
+++ b/app/views/DR/ReportScreen/ReportType.js
@@ -25,11 +25,11 @@ export default function ReportScreen({
   const { t } = useTranslation();
 
   const [, setGlobalState] = useContext(context);
-  const [users, setUsers] = useState([]);
+  const [userList, setUserList] = useState([]);
 
   useEffect(() => {
     GetStoreData('users', false).then(data => {
-      setUsers(data !== null ? data : []);
+      data && setUserList(data);
     });
   }, []);
 
@@ -55,7 +55,7 @@ export default function ReportScreen({
             <Text style={[styles.text, { marginVertical: 30, fontSize: 17 }]}>
               {t('report.usage.subtitle')}
             </Text>
-            {!(users.length > 0 && getMyself(users)) && (
+            {!getMyself(userList) && (
               <Button
                 style={[
                   styles.buttons,

--- a/app/views/DR/UserInfoScreen/index.js
+++ b/app/views/DR/UserInfoScreen/index.js
@@ -103,10 +103,7 @@ export default function UserInfo({
               let name = '';
               if (data !== null) {
                 data.map(user => {
-                  if (
-                    (body.cid !== undefined && user.data.cid === body.cid) ||
-                    (body.nssid !== undefined && user.data.nssid === body.nssid)
-                  ) {
+                  if (user.covidId === covidId) {
                     same = true;
                     name = user.name;
                   }

--- a/app/views/DR/UserInfoScreen/index.js
+++ b/app/views/DR/UserInfoScreen/index.js
@@ -127,10 +127,15 @@ export default function UserInfo({
             setShowValidationDialog(true);
             setPositiveError(true);
           } else {
+            let checkCoincidense = false;
             const userList = await GetStoreData('users', false);
-            const checkCoincidense = userList.some(
-              user => user.covidId === covidId,
-            );
+
+            if (userList) {
+              checkCoincidense = userList.some(
+                user => user.covidId === covidId,
+              );
+            }
+
             if (!checkCoincidense)
               navigation.navigate('PositiveOnboarding', {
                 positive,

--- a/app/views/DR/UserInfoScreen/positiveOnboarding.js
+++ b/app/views/DR/UserInfoScreen/positiveOnboarding.js
@@ -42,7 +42,7 @@ const PositiveOnboarding = ({ route, navigation }) => {
         navigation.navigate('EpidemiologicResponse', {
           screen: 'EpidemiologicReport',
           params: { nickname: nickname, path: false },
-          showDialog: true,
+          showDialog: use === 'mySelf' ? true : false,
         });
       } else {
         navigation.navigate('Report');

--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -119,7 +119,7 @@ export const SettingsScreen = ({ navigation }) => {
             onPress={locationToggleButtonPressed}
           />
           <Divider />
-          {getMyself(userList) && (
+          {userList.length > 0 && getMyself(userList) && (
             <Item
               last
               label={
@@ -166,13 +166,13 @@ export const SettingsScreen = ({ navigation }) => {
             last
             icon={{ name: 'shield-virus', color: '#0161F2', size: 26 }}
             label={
-              checkPositiveCovidUser(userList)
+              userList.length > 0 && checkPositiveCovidUser(userList)
                 ? t('label.epidemiologic_report_title')
                 : t('label.epidemiologic_report_title_new')
             }
             description={t('label.epidemiologic_report_subtitle')}
             onPress={() => {
-              checkPositiveCovidUser(userList)
+              userList.length > 0 && checkPositiveCovidUser(userList)
                 ? navigation.navigate('UseFor')
                 : navigation.navigate('ReportScreen', { back: true });
             }}

--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -25,7 +25,7 @@ export const SettingsScreen = ({ navigation }) => {
   const { t } = useTranslation();
   const [isLogging, setIsLogging] = useState(undefined);
   const [isSharing, setIsSharing] = useState(false);
-  const [isCovidPositive, setIsCovpositive] = useState([]);
+  const [userList, setUserList] = useState([]);
   const [userLocale, setUserLocale] = useState(
     supportedDeviceLanguageOrEnglish(),
   );
@@ -43,7 +43,7 @@ export const SettingsScreen = ({ navigation }) => {
     );
     GetStoreData('users', false).then(users => {
       if (users) {
-        setIsCovpositive(users);
+        setUserList(users);
       }
     });
   };
@@ -119,24 +119,22 @@ export const SettingsScreen = ({ navigation }) => {
             onPress={locationToggleButtonPressed}
           />
           <Divider />
-          {isCovidPositive.length > 0 &&
-            checkPositiveCovidUser(isCovidPositive) &&
-            getMyself(isCovidPositive) && (
-              <Item
-                last
-                label={
-                  isSharing
-                    ? t('label.share_loc_active')
-                    : t('label.share_loc_inactive')
-                }
-                icon={
-                  isSharing
-                    ? { name: 'check-circle', color: 'lightgreen', size: 27 }
-                    : { name: 'times-circle', color: 'red', size: 27 }
-                }
-                onPress={subcribeLocationToggleButtonPressed}
-              />
-            )}
+          {getMyself(userList) && (
+            <Item
+              last
+              label={
+                isSharing
+                  ? t('label.share_loc_active')
+                  : t('label.share_loc_inactive')
+              }
+              icon={
+                isSharing
+                  ? { name: 'check-circle', color: 'lightgreen', size: 27 }
+                  : { name: 'times-circle', color: 'red', size: 27 }
+              }
+              onPress={subcribeLocationToggleButtonPressed}
+            />
+          )}
           <NativePicker
             items={LOCALE_LIST}
             value={userLocale}
@@ -168,18 +166,15 @@ export const SettingsScreen = ({ navigation }) => {
             last
             icon={{ name: 'shield-virus', color: '#0161F2', size: 26 }}
             label={
-              isCovidPositive.length > 0 &&
-              checkPositiveCovidUser(isCovidPositive)
+              checkPositiveCovidUser(userList)
                 ? t('label.epidemiologic_report_title')
                 : t('label.epidemiologic_report_title_new')
             }
             description={t('label.epidemiologic_report_subtitle')}
             onPress={() => {
-              if (isCovidPositive.length > 0) {
-                navigation.navigate('UseFor');
-              } else {
-                navigation.navigate('ReportScreen', { back: true });
-              }
+              checkPositiveCovidUser(userList)
+                ? navigation.navigate('UseFor')
+                : navigation.navigate('ReportScreen', { back: true });
             }}
           />
         </Section>


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
In this ticket I fixed the follow:
- There was a problem reporting positive users, No matter what the case is, it keeps asking you to share your location even when you are not the owner of the phone.
- Setting the user state in the phone's storage when the user turns out to be covid positive
- With negative covid users a condition was missing when the user had already reported symptoms so that it would not ask for the nickname again
#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
Fix: [280](https://trello.com/c/8Fi3FBAk/280-as-a-user-i-want-to-see-all-the-positive-users-registered-in-my-phone-in-support-for-virus-positives-screen)
#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
![image](https://user-images.githubusercontent.com/43874147/93804677-a9690900-fc14-11ea-9a39-2fb0d32d2f3c.png)
#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- `git pull && git checkout Fix/280-fixing-report-and-register-covid-user`
- Head over to report section and report as many positive users you can
- Go to settings and there should be a section to support positive users
- You should see all the user you have been reported.
- Report yourself as negative user and then with postman set it as positive, close and open the app and It should show you a message notifying that you have tested positive for COVID in laboratory results

**Note:** use the user state endpoint to set yourself as positive