### PR TITLE
Feat/278 dashboard synchronized coronavirusrd.gob

### DIFF
--- a/app/components/DR/CasesStatistics.js
+++ b/app/components/DR/CasesStatistics.js
@@ -76,7 +76,7 @@ class CasesStatistics extends React.Component {
 
       this.setState(({ lastDateAvaiblable }) => ({
         lastDateAvaiblable:
-          lastDateAvaiblable.length < 1 ? date : lastDateAvaiblable,
+          lastDateAvaiblable > date ? lastDateAvaiblable : date,
         date,
         ...this.separateOrAbreviate({
           confirmed,

--- a/app/components/DR/CasesStatistics.js
+++ b/app/components/DR/CasesStatistics.js
@@ -18,6 +18,7 @@ class CasesStatistics extends React.Component {
       recovered: 0,
       current: 0,
       date: '',
+      lastDateAvaiblable: '',
     };
   }
   componentDidMount() {
@@ -73,7 +74,9 @@ class CasesStatistics extends React.Component {
 
       date = date === '' ? dateOfData : date;
 
-      this.setState(() => ({
+      this.setState(({ lastDateAvaiblable }) => ({
+        lastDateAvaiblable:
+          lastDateAvaiblable.length < 1 ? date : lastDateAvaiblable,
         date,
         ...this.separateOrAbreviate({
           confirmed,
@@ -88,7 +91,14 @@ class CasesStatistics extends React.Component {
 
   render() {
     const { t, navigation, refresh } = this.props;
-    const { confirmed, deaths, recovered, current, date } = this.state;
+    const {
+      confirmed,
+      deaths,
+      recovered,
+      current,
+      date,
+      lastDateAvaiblable,
+    } = this.state;
 
     return (
       <>
@@ -131,6 +141,8 @@ class CasesStatistics extends React.Component {
             deaths={deaths}
             recovered={recovered}
             current={current}
+            date={lastDateAvaiblable}
+            showMap={lastDateAvaiblable === date}
           />
         </View>
       </>

--- a/app/components/DR/DashboardCards.js
+++ b/app/components/DR/DashboardCards.js
@@ -1,6 +1,7 @@
+import moment from 'moment';
 import { Card, Text } from 'native-base';
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { Alert, TouchableOpacity } from 'react-native';
 
 import Colors from '../../constants/colors';
 import styles from '../../views/DR/HomeScreen/style';
@@ -12,6 +13,8 @@ export default function DashboardCards({
   deaths,
   recovered,
   current,
+  date,
+  showMap,
 }) {
   const dashboardCategories = [
     { label: 'label.positive_label', styles: '', value: confirmed },
@@ -39,9 +42,17 @@ export default function DashboardCards({
       style={styles.shadowBorder}
       key={obj.label}
       onPress={() =>
-        navigation.navigate('Details', {
-          source: { uri: CONFIRMED_COVID_CASES_URL },
-        })
+        showMap
+          ? navigation.navigate('Details', {
+              source: { uri: CONFIRMED_COVID_CASES_URL },
+            })
+          : Alert.alert(
+              t('label.attention'),
+              `${t('dashboard.attention_message')} ${moment(
+                date,
+                'YYYY-MM-DD',
+              ).format('DD-MM-YYYY')}`,
+            )
       }>
       <Card style={styles.infoCards}>
         <Text style={[styles.dataText, obj.styles]}>{obj.value}</Text>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -14,6 +14,7 @@
     "ok": "Ok"
   },
   "dashboard": {
+    "attention_message": "Map only available for the date",
     "error_title": "Oops!, an error has occurred",
     "error_message": "Sorry! We do not have the information for the specified date in our database, please try another date"
   },

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -10,6 +10,7 @@
     "ok": "Ok"
   },
   "dashboard": {
+    "attention_message": "Mapa solo disponible para la fecha",
     "error_title": "Oops!, se ha producido un error",
     "error_message": "Lo sentimos!, no tenemos la información de la fecha especificada en nuestra base de datos, por favor pruebe con otra fecha"
   },


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
redirecting to coronavirus map just if dashboard and site date matches otherwise it will display an alert message
#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
Feat: [278](https://trello.com/c/FxKX6QkQ/278-as-a-user-i-want-to-see-the-cases-dashboard-synchronized-with-coronavirusrdgob)

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- `git pull && git  checkout Feat/278-dashboard-synchronized-coronavirusrd.gob`
- Change the date of the calendar dashboard and hit one of the card
- it should display an alert message if the date does not match
