### PR TITLE
Fixing problem with latest data available on dashboard

### DIFF
--- a/app/components/DR/CasesStatistics.js
+++ b/app/components/DR/CasesStatistics.js
@@ -72,7 +72,6 @@ class CasesStatistics extends React.Component {
     const data = await getAllCases(date);
 
     if (!data[0].casos_acumulados && !firstUse) {
-      console.log(data[0].casos_acumulados);
       Alert.alert(t('dashboard.error_title'), t('dashboard.error_message'));
     }
 

--- a/app/components/DR/CasesStatistics.js
+++ b/app/components/DR/CasesStatistics.js
@@ -83,10 +83,7 @@ class CasesStatistics extends React.Component {
         );
       }
 
-      const newDate =
-        !date || date.length === 0
-          ? moment().format('YYYY-MM-DD')
-          : moment(date).format('YYYY-MM-DD');
+      const newDate = moment(data[1]).add(1, 'day');
 
       this.setState(({ lastDateAvaiblable }) => ({
         lastDateAvaiblable:

--- a/app/services/DR/getAllCases.js
+++ b/app/services/DR/getAllCases.js
@@ -21,12 +21,13 @@ export async function getAllCases(date) {
     }
 
     if (!response.data[0].casos_acumulados) {
-      const dateBefore = moment(date)
+      date = moment(date)
         .subtract(1, 'day')
         .format('YYYY-MM-DD');
-      response = await responseFunc(dateBefore, savedToken);
+      response = await responseFunc(date, savedToken);
     }
 
+    response.data.push(date);
     return response.data;
   } catch (err) {
     return err.response.status;

--- a/app/services/DR/getAllCases.js
+++ b/app/services/DR/getAllCases.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 import { MEPID_URL_API } from '../../constants/DR/baseUrls';
 import fetch from '../../helpers/Fetch';
 import { getTokenMepid } from './getToken';
@@ -20,14 +18,6 @@ export async function getAllCases(date) {
       response = await responseFunc(date, savedToken);
     }
 
-    if (!response.data[0].casos_acumulados) {
-      date = moment(date)
-        .subtract(1, 'day')
-        .format('YYYY-MM-DD');
-      response = await responseFunc(date, savedToken);
-    }
-
-    response.data.push(date);
     return response.data;
   } catch (err) {
     return err.response.status;

--- a/app/services/DR/getAllCases.js
+++ b/app/services/DR/getAllCases.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { MEPID_URL_API } from '../../constants/DR/baseUrls';
 import fetch from '../../helpers/Fetch';
 import { getTokenMepid } from './getToken';
@@ -5,17 +7,24 @@ import { getTokenMepid } from './getToken';
 export async function getAllCases(date) {
   let savedToken = await getTokenMepid();
 
-  const responseFunc = token =>
+  const responseFunc = (date, token) =>
     fetch(`${MEPID_URL_API}/api/boletin/${date}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
 
   try {
-    let response = await responseFunc(savedToken);
+    let response = await responseFunc(date, savedToken);
 
     if (response.data.error) {
       savedToken = await getTokenMepid(true);
-      response = await responseFunc(savedToken);
+      response = await responseFunc(date, savedToken);
+    }
+
+    if (!response.data[0].casos_acumulados) {
+      const dateBefore = moment(date)
+        .subtract(1, 'day')
+        .format('YYYY-MM-DD');
+      response = await responseFunc(dateBefore, savedToken);
     }
 
     return response.data;


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description: Fixing problem with latest data available on dashboard, it was not showing initial data when there was no data from today.

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues: [Ticket #285](https://trello.com/c/W4G67GKy/285-as-a-dev-i-want-to-replace-the-current-implementation-of-getting-the-statistical-bulletins-data)

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots: Not needed

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

Force changing to `true` the if on line 23 in the `file app/services/DR/getAllCases.js` this should show the data from a day before today.

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
